### PR TITLE
Add remote state support with file-based locking

### DIFF
--- a/bin/biosphere
+++ b/bin/biosphere
@@ -6,6 +6,7 @@ require 'ostruct'
 require 'pp'
 require "awesome_print"
 require 'colorize'
+require 'biosphere/s3.rb'
 
 class BiosphereOpts
 
@@ -23,8 +24,11 @@ class BiosphereOpts
 
 			opts.separator ""
 			opts.separator "Commands:"
-			opts.separator "\tplan\tRun the planning phase"
 			opts.separator "\tjson\tWrite tf files as json into build directory"
+			opts.separator "\tplan\tRun the planning phase"
+			opts.separator "\tcommit\tCommit changes and update the infrastructure"
+			opts.separator "\tlock\tAcquire lock for remote state"
+			opts.separator "\tunlock\tRelease lock for remote state"
 			opts.separator "\taction [action]\tCall an action defined in the application .rb files"
 			opts.separator ""
 
@@ -36,7 +40,6 @@ class BiosphereOpts
 			opts.on("--src PATH", "Directory where the application .rb files are") do |path|
 				options.src = path
 			end
-
 
 			opts.on("--build PATH", "Directory where to build json files") do |path|
 				options.build = path
@@ -85,6 +88,13 @@ if options.build
 	end
 end
 
+if options.src && suite.node[:settings][:cluster_name] && suite.node[:settings][:s3_bucket]
+	if suite.node[:settings][:s3_bucket].nil? || suite.node[:settings][:s3_bucket].empty? || suite.node[:settings][:cluster_name].nil? || suite.node[:settings][:cluster_name].empty?
+		puts "\nNo S3 bucket or cluster name defined in configuration, can't continue"
+		exit 1
+	end
+	s3 = S3.new(suite.node[:settings][:s3_bucket], suite.node[:settings][:cluster_name])
+end
 
 if ARGV[0] == "json" && options.src
 	suite.evaluate_resources()
@@ -106,6 +116,7 @@ if ARGV[0] == "json" && options.src
 elsif ARGV[0] == "plan" && options.src
 	suite.evaluate_plans()
 	ap suite.node, :indent=>-4
+
 elsif ARGV[0] == "action" && options.src
 	context = Biosphere::ActionContext.new()
 
@@ -118,6 +129,44 @@ elsif ARGV[0] == "action" && options.src
 	end
 
 	suite.save_node()
+
+elsif ARGV[0] == "commit" && options.src
+	s3.set_lock()
+	s3.retrieve("#{options.src}build/terraform.tfstate")
+	tf_plan = %x( terraform plan -state=#{options.src}build/terraform.tfstate #{options.src}/build/ )
+	puts tf_plan
+	answer = ""
+	while answer.empty? || (answer != "y" && answer != "n")
+		print "\nDoes the plan look reasonable? (Answering yes will apply the changes) y/n: "
+		answer = STDIN.gets.chomp
+	end
+
+	if answer == "n"
+		puts "\nOk, will not proceed with commit"
+	elsif answer == "y"
+		puts "\nApplying the changes (this may take several minutes)"
+		tf_apply = %x( terraform apply -state=#{options.src}build/terraform.tfstate #{options.src}/build/ )
+		puts tf_apply
+	end
+
+	s3.save("#{options.src}build/terraform.tfstate")
+	s3.save("#{options.src}state.node")
+
+	puts "\nRemoving local state from #{options.src}build/terraform.tfstate"
+	begin
+		File.delete("#{options.src}build/terraform.tfstate")
+	rescue
+		puts "Couldn't delete the local state file!"
+	end
+
+	s3.release_lock()
+
+elsif ARGV[0] == "lock"
+	s3.set_lock()
+
+elsif ARGV[0] == "unlock"
+	s3.release_lock()
+
 else
 	STDERR.puts "\nERROR: Unknown command #{ARGV[0]}. Maybe you wanted to do: \"biosphere action #{ARGV[0]}\"?"
 	exit -1

--- a/bin/biosphere
+++ b/bin/biosphere
@@ -10,10 +10,17 @@ require 'biosphere/s3.rb'
 
 class BiosphereOpts
 
+	def self.normalize_path(path)
+		if path[-1] != '/'
+			path += '/'
+		end
+		return path
+	end
+
 	def self.parse(args)
 
 		options = OpenStruct.new
-		options.build = "build"
+		options.build_dir = "build"
 		options.src = "./"
 		options.version = ::Biosphere::Version
 
@@ -24,7 +31,7 @@ class BiosphereOpts
 
 			opts.separator ""
 			opts.separator "Commands:"
-			opts.separator "\tjson\tWrite tf files as json into build directory"
+			opts.separator "\tbuild\tWrite tf files as json into build directory"
 			opts.separator "\tplan\tRun the planning phase"
 			opts.separator "\tcommit\tCommit changes and update the infrastructure"
 			opts.separator "\tlock\tAcquire lock for remote state"
@@ -38,11 +45,11 @@ class BiosphereOpts
 			end
 
 			opts.on("--src PATH", "Directory where the application .rb files are") do |path|
-				options.src = path
+				options.src = normalize_path(path)
 			end
 
-			opts.on("--build PATH", "Directory where to build json files") do |path|
-				options.build = path
+			opts.on("--build-dir PATH", "Directory where to build json files") do |path|
+				options.build_dir = normalize_path(path)
 			end
 
 		end
@@ -65,7 +72,7 @@ if ARGV.length == 0
 end
 
 if !File.directory?(options.src)
-	STDERR.puts "Directory #{options.build} is not a directory or it doesn't exists."
+	STDERR.puts "Directory #{options.build_dir} is not a directory or it doesn't exists."
 	exit -1
 end
 
@@ -79,16 +86,7 @@ if options.src
 		STDERR.puts "No files found. Are you in the right directory where your biosphere .rb files are?"
 		exit -1
 	end
-end
 
-if options.build
-	if !File.directory?(options.build)
-		STDERR.puts "Creating build directory #{options.build} because it was missing"
-		Dir.mkdir(options.build)
-	end
-end
-
-if options.src && suite.node[:settings][:cluster_name] && suite.node[:settings][:s3_bucket]
 	if suite.node[:settings][:s3_bucket].nil? || suite.node[:settings][:s3_bucket].empty? || suite.node[:settings][:cluster_name].nil? || suite.node[:settings][:cluster_name].empty?
 		puts "\nNo S3 bucket or cluster name defined in configuration, can't continue"
 		exit 1
@@ -96,21 +94,28 @@ if options.src && suite.node[:settings][:cluster_name] && suite.node[:settings][
 	s3 = S3.new(suite.node[:settings][:s3_bucket], suite.node[:settings][:cluster_name])
 end
 
-if ARGV[0] == "json" && options.src
+if options.build_dir
+	if !File.directory?(options.build_dir)
+		STDERR.puts "Creating build directory #{options.build_dir} because it was missing"
+		Dir.mkdir(options.build_dir)
+	end
+end
+
+if ARGV[0] == "build" && options.src
 	suite.evaluate_resources()
 
-	if !File.directory?(options.build)
-		STDERR.puts "Directory #{options.build} is not a directory or it doesn't exists."
+	if !File.directory?(options.build_dir)
+		STDERR.puts "Directory #{options.build_dir} is not a directory or it doesn't exists."
 		exit -1
 	end
 
 	count = 0
-	suite.write_json_to(options.build) do |file_name, destination, str, proxy|
+	suite.write_json_to(options.build_dir) do |file_name, destination, str, proxy|
 		puts "Wrote #{str.length} bytes from #{file_name} to #{destination} (#{proxy.export["resource"].length} resources)"
 		count = count + 1
 	end
 
-	puts "Wrote #{count} files into #{options.build}"
+	puts "Wrote #{count} files into #{options.build_dir}"
 	suite.save_node()
 
 elsif ARGV[0] == "plan" && options.src
@@ -118,9 +123,10 @@ elsif ARGV[0] == "plan" && options.src
 	ap suite.node, :indent=>-4
 
 elsif ARGV[0] == "action" && options.src
+	s3.retrieve("#{options.build_dir}terraform.tfstate")
+	s3.retrieve("#{options.build_dir}state.node")
 	context = Biosphere::ActionContext.new()
-
-	context.build_directory = options.build
+	context.build_directory = options.build_dir
 
 	if suite.call_action(ARGV[1], context)
 		STDERR.puts "Executing action #{ARGV[1]}"
@@ -132,9 +138,10 @@ elsif ARGV[0] == "action" && options.src
 
 elsif ARGV[0] == "commit" && options.src
 	s3.set_lock()
-	s3.retrieve("#{options.src}build/terraform.tfstate")
-	tf_plan = %x( terraform plan -state=#{options.src}build/terraform.tfstate #{options.src}/build/ )
-	puts tf_plan
+	s3.retrieve("#{options.build_dir}terraform.tfstate")
+	s3.retrieve("#{options.build_dir}state.node")
+	tf_plan = %x( terraform plan -state=#{options.build_dir}terraform.tfstate #{options.build_dir} )
+	puts "\n" + tf_plan
 	answer = ""
 	while answer.empty? || (answer != "y" && answer != "n")
 		print "\nDoes the plan look reasonable? (Answering yes will apply the changes) y/n: "
@@ -145,18 +152,10 @@ elsif ARGV[0] == "commit" && options.src
 		puts "\nOk, will not proceed with commit"
 	elsif answer == "y"
 		puts "\nApplying the changes (this may take several minutes)"
-		tf_apply = %x( terraform apply -state=#{options.src}build/terraform.tfstate #{options.src}/build/ )
-		puts tf_apply
-	end
-
-	s3.save("#{options.src}build/terraform.tfstate")
-	s3.save("#{options.src}state.node")
-
-	puts "\nRemoving local state from #{options.src}build/terraform.tfstate"
-	begin
-		File.delete("#{options.src}build/terraform.tfstate")
-	rescue
-		puts "Couldn't delete the local state file!"
+		tf_apply = %x( terraform apply -state=#{options.build_dir}terraform.tfstate #{options.build_dir})
+		puts "\n" + tf_apply
+		s3.save("#{options.build_dir}terraform.tfstate")
+		s3.save("#{options.src}state.node")
 	end
 
 	s3.release_lock()

--- a/biosphere.gemspec
+++ b/biosphere.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency('kubeclient', '2.1.0')
   s.add_dependency('hashdiff', '0.3.0')
   s.add_dependency('colorize', '0.8.1')
+  s.add_dependency('aws-sdk', '~> 2')
 end

--- a/lib/biosphere/s3.rb
+++ b/lib/biosphere/s3.rb
@@ -37,7 +37,7 @@ class S3
                 f.puts(resp.body.read)
             end
         rescue Aws::S3::Errors::NoSuchKey
-            puts "\nCouldn't find existing remote state. Creating a new state file."
+            puts "\nCouldn't find remote file #{filename} from S3."
         rescue
             puts "\nError occurred while fetching the remote state, can't continue."
             puts "Error: #{$!}"

--- a/lib/biosphere/s3.rb
+++ b/lib/biosphere/s3.rb
@@ -1,0 +1,82 @@
+require 'aws-sdk'
+
+class S3
+    def initialize(bucket, main_key)
+        @client = Aws::S3::Client.new
+        @bucket_name = bucket
+        @main_key = main_key
+    end
+
+    def save(path_to_file)
+        puts "\nSaving #{path_to_file} to S3"
+        filename = path_to_file.split('/')[-1]
+        begin
+            File.open(path_to_file, 'rb') do |file|
+                @client.put_object({
+                    :bucket => @bucket_name,
+                    :key => "#{@main_key}/#{filename}",
+                    :body => file
+                })
+            end
+        rescue
+            puts "\nError occurred while saving the remote state, can't continue"
+            puts "Error: #{$!}"
+            exit 1
+        end
+    end
+
+    def retrieve(path_to_file)
+        filename = path_to_file.split('/')[-1]
+        puts "\nFetching #{filename} from S3"
+        begin
+            resp = @client.get_object({
+                :bucket => @bucket_name,
+                :key => "#{@main_key}/#{filename}"
+            })
+            File.open(path_to_file, 'w') do |f|
+                f.puts(resp.body.read)
+            end
+        rescue Aws::S3::Errors::NoSuchKey
+            puts "\nCouldn't find existing remote state. Creating a new state file."
+        rescue
+            puts "\nError occurred while fetching the remote state, can't continue."
+            puts "Error: #{$!}"
+            exit 1
+        end
+    end
+
+    def set_lock()
+        begin
+            resp = @client.get_object({
+                :bucket => @bucket_name,
+                :key => "#{@main_key}/biosphere.lock"
+            })
+            puts "\nThe remote state is locked since #{resp.last_modified}\nCan't continue."
+            exit 1
+        rescue Aws::S3::Errors::NoSuchKey
+            puts "\nRemote state was not locked, adding the lockfile.\n"
+            @client.put_object({
+                :bucket => @bucket_name,
+                :key => "#{@main_key}/biosphere.lock"
+            })
+        rescue
+            puts "\There was an error while accessing the lock. Can't continue.'"
+            puts "Error: #{$!}"
+            exit 1
+        end
+    end
+
+    def release_lock()
+        begin
+            @client.delete_object({
+                :bucket => @bucket_name,
+                :key => "#{@main_key}/biosphere.lock"
+            })
+        rescue
+            puts "\nCouldn't release the lock!"
+            puts "Error: #{$!}"
+            exit 1
+        end
+        puts "\nLock released successfully"
+    end
+end


### PR DESCRIPTION
This provides only the basic functionality. Terraform errors for example are not handled correctly yet. Will also need to refactor majority of the commit logic out of bin/biosphere