### PR TITLE
Feature/deployment name scope

### DIFF
--- a/bin/biosphere
+++ b/bin/biosphere
@@ -164,6 +164,23 @@ elsif ARGV[0] == "deployment" && options.src
         puts "Deployment: #{name}"
     end
 
+elsif ARGV[0] == "statereset" && options.src
+
+    answer = ""
+    while answer.empty? || (answer != "y" && answer != "n")
+        print "\nAre you sure you want to do a full state reset for #{options.build_dir} y/n: "
+        answer = STDIN.gets.chomp
+    end
+
+    if answer == "n"
+        puts "\nOk, will not proceed with state reset"
+    elsif answer == "y"
+        state = Biosphere::State.new
+        state.filename = "#{options.build_dir}/state.node"
+        state.save()
+        s3.save("#{options.build_dir}/state.node")
+    end
+
 elsif ARGV[0] == "commit" && options.src
 
     if !ARGV[1]

--- a/lib/biosphere/kube.rb
+++ b/lib/biosphere/kube.rb
@@ -176,7 +176,7 @@ class Biosphere
 
         def self.load_resources(file, context={})
             resources = []
-            #puts "Loading file #{File.absolute_path(file)}"
+            puts "Loading file #{File.absolute_path(file)}"
             data = IO.read(file)
             begin
                 str = ERB.new(data).result(OpenStruct.new(context).instance_eval { binding })
@@ -184,7 +184,7 @@ class Biosphere
                 puts "Error evaluating erb templating for #{file}. Error: #{e}"
                 m = /\(erb\):([0-9]+):/.match(e.backtrace.first)
                 if m
-                    puts "Error at line #{m[1]}. This is before ERB templating."
+                    puts "Error at line #{m[1]}. This is before ERB templating. Remember to run biosphere build if you changed settings."
                     linenumber = m[1].to_i
                     if linenumber > 0 # Linenumbers seems to be off with 1 as the array is starting at zero
                         linenumber = linenumber - 1

--- a/lib/biosphere/s3.rb
+++ b/lib/biosphere/s3.rb
@@ -51,6 +51,24 @@ class S3
         end
     end
 
+    def delete_object(path_to_file)
+        filename = path_to_file.split('/')[-1]
+        key = "#{@main_key}/#{filename}"
+        puts "Fetching #{filename} from S3 from #{key}"
+        begin
+            resp = @client.delete_object({
+                :bucket => @bucket_name,
+                :key => key
+            })
+        rescue Aws::S3::Errors::NoSuchKey
+            puts "Couldn't find remote file #{filename} from S3 at #{key}"
+        rescue
+            puts "\nError occurred while deleting file #{path_to_file}."
+            puts "Error: #{$!}"
+            exit 1
+        end
+    end
+
     def set_lock()
         begin
             resp = @client.get_object({

--- a/lib/biosphere/terraformproxy.rb
+++ b/lib/biosphere/terraformproxy.rb
@@ -81,10 +81,17 @@ class Biosphere
         end
 
         def id_of(type,name)
+            if self.name
+                name = self.name + "_" + name
+            end
             "${#{type}.#{name}.id}"
         end
 
         def output_of(type, name, *values)
+            if self.name
+                name = self.name + "_" + name
+            end
+            
             "${#{type}.#{name}.#{values.join(".")}}"
         end
 

--- a/spec/biosphere/suite_spec.rb
+++ b/spec/biosphere/suite_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Biosphere::Suite do
         s.load_all("spec/biosphere/suite_test1")
         s.evaluate_resources()
 
-        expect(s.deployments["test1"].export["resource"]["type"]["name"]).to eq({:foo => "file1"})
-        expect(s.deployments["test2"].export["resource"]["type"]["name"]).to eq({:foo => "file2"})
+        expect(s.deployments["test1"].export["resource"]["type"]["test1_name"]).to eq({:foo => "file1"})
+        expect(s.deployments["test2"].export["resource"]["type"]["test2_name"]).to eq({:foo => "file2"})
     end
 
     it "require_relative works with suite" do
@@ -23,8 +23,8 @@ RSpec.describe Biosphere::Suite do
         s.load_all("spec/biosphere/suite_test2")
         s.evaluate_resources()
 
-        expect(s.deployments["TestDeployment"].export["resource"]["type"]["name1"]).to eq({:foo => "I'm Garo"})
-        expect(s.deployments["TestDeployment"].export["resource"]["type"]["name2"]).to eq({:property => "test"})
+        expect(s.deployments["TestDeployment"].export["resource"]["type"]["helper_name1"]).to eq({:foo => "I'm Garo"})
+        expect(s.deployments["TestDeployment"].export["resource"]["type"]["helper_name2"]).to eq({:property => "test"})
     end
 
     it "can find action from all files" do
@@ -44,8 +44,8 @@ RSpec.describe Biosphere::Suite do
             FileUtils.remove_dir("build")
         end
         s.write_json_to("build")
-        expect(JSON.parse(IO.read("build/test1.json.tf"))["resource"]["type"]["name"]).to eq({"foo" => "file1"})
-        expect(JSON.parse(IO.read("build/test2.json.tf"))["resource"]["type"]["name"]).to eq({"foo" => "file2"})
+        expect(JSON.parse(IO.read("build/test1.json.tf"))["resource"]["type"]["test1_name"]).to eq({"foo" => "file1"})
+        expect(JSON.parse(IO.read("build/test2.json.tf"))["resource"]["type"]["test2_name"]).to eq({"foo" => "file2"})
 
         if File.directory?("build")
             FileUtils.remove_dir("build")

--- a/spec/biosphere/suite_test1/build/output.tfstate
+++ b/spec/biosphere/suite_test1/build/output.tfstate
@@ -9,12 +9,12 @@
                 "root"
             ],
             "outputs": {
-                "foobar": {
+                "test1_foobar": {
                     "sensitive": false,
                     "type": "string",
                     "value": "hello"
                 },
-                "etcd-0": {
+                "test1_etcd-0": {
                     "sensitive": false,
                     "type": "string",
                     "value": "1.2.3.4"

--- a/spec/biosphere/suite_test1/file1.rb
+++ b/spec/biosphere/suite_test1/file1.rb
@@ -6,7 +6,7 @@ class TestDeployment1 < ::Biosphere::Deployment
             set :foo, "file1"
         end
 
-        output "foobar", "${aws_instance.foobar.0.public_ip}" do |key, value|
+        output "foobar", output_of("aws_instance", "foobar", "0", "public_ip") do |deployment_name, key, value|
             node[:foobar] = [key, value]
         end
 
@@ -15,4 +15,4 @@ end
 
 action "one", "desc"
 
-TestDeployment1.new(suite, {deployment_name: "test1"})
+TestDeployment1.new(suite, "test1")

--- a/spec/biosphere/suite_test1/file2.rb
+++ b/spec/biosphere/suite_test1/file2.rb
@@ -12,4 +12,4 @@ end
 
 action "two", "desc"
 
-TestDeployment2.new(suite, {deployment_name: "test2"})
+TestDeployment2.new(suite, "test2")

--- a/spec/biosphere/suite_test2/main_file.rb
+++ b/spec/biosphere/suite_test2/main_file.rb
@@ -6,7 +6,7 @@ load 'lib/template_file.rb'
 class TestDeployment < ::Biosphere::Deployment
 
     def setup(settings)
-        helper = DeploymentHelper.new(self)
+        helper = DeploymentHelper.new(self, "helper")
         helper.my_template("Garo")
 
         resource "type", "name3" do
@@ -15,4 +15,4 @@ class TestDeployment < ::Biosphere::Deployment
     end
 end
 
-TestDeployment.new(suite, {deployment_name: "TestDeployment"})
+TestDeployment.new(suite, "TestDeployment")

--- a/spec/biosphere/suite_test3/main.rb
+++ b/spec/biosphere/suite_test3/main.rb
@@ -1,0 +1,24 @@
+
+class TestSubDeployment1 < ::Biosphere::Deployment
+
+    def setup(settings)
+        resource "type", "name" do
+            set :foo, "file1"
+        end
+
+    end
+end
+
+class TestDeployment1 < ::Biosphere::Deployment
+
+    def setup(settings)
+        sub = TestSubDeployment1.new(self, "sub1")
+        sub2 = TestSubDeployment1.new(self, "sub2")
+
+        resource "type", "name" do
+            set :foo, "file1"
+        end        
+    end
+end
+
+TestDeployment1.new(suite, "main")

--- a/spec/biosphere/terraformproxy_spec.rb
+++ b/spec/biosphere/terraformproxy_spec.rb
@@ -3,8 +3,6 @@ require 'pp'
 
 RSpec.describe Biosphere::TerraformProxy do
 
-    default_settings = { deployment_name: "unnamed" }
-
     describe "defining resources using Deployments" do
         it "can define a resource in the constructor" do
 
@@ -20,13 +18,13 @@ RSpec.describe Biosphere::TerraformProxy do
                         end
                     end
                 end
-                a = TestDeployment.new(default_settings)
+                a = TestDeployment.new("unnamed")
 
                 a.evaluate_resources()
                 res[:a] = a
             end
 
-            expect(res[:a].export["resource"]["type"]["name"]).to eq({:foo => "one", :bar=> true})
+            expect(res[:a].export["resource"]["type"]["unnamed_name"]).to eq({:foo => "one", :bar=> true})
 
         end
     end


### PR DESCRIPTION
Refactor deployments to have names

This patch allows a deployment to have multiple sub-instances
of a same sub-deployment but with different names. Technically
this is done by prepending the deployment name to the resource names
inside terraform.

This is a breaking change!

- output function callback will now have a new parameter
"deployment_name" as the first parameter.

- all resource references should now use id_of() or output_of()
macros. Example: output_of("aws_instance", "master", "public_ip")

